### PR TITLE
ci: install pnpm before pnpm steps (hotfix)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      - name: Install pnpm
+        run: npm install -g pnpm@10.13.1
       - name: Enable pnpm via Corepack
         run: corepack enable && corepack prepare pnpm@10.13.1 --activate
       - name: Install dependencies (pnpm)
@@ -56,6 +58,8 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      - name: Install pnpm
+        run: npm install -g pnpm@10.13.1
       - name: Enable pnpm via Corepack
         run: corepack enable && corepack prepare pnpm@10.13.1 --activate
       - name: Install dependencies (pnpm)


### PR DESCRIPTION
Fix failing runs: add 'npm i -g pnpm@10.13.1' before any pnpm commands in test/build jobs.\n\nRef: failing error 'Unable to locate executable file: pnpm'.